### PR TITLE
Improve API robustness and remove public dependencies

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -21,7 +21,7 @@ pub enum SnmpError {
     #[error("Nom error")]
     NomError(ErrorKind),
     #[error("BER error")]
-    BerError(Error),
+    BerError(#[from] Error),
 }
 
 impl<I> ParseError<I> for SnmpError {
@@ -30,12 +30,6 @@ impl<I> ParseError<I> for SnmpError {
     }
     fn append(_input: I, kind: ErrorKind, _other: Self) -> Self {
         SnmpError::NomError(kind)
-    }
-}
-
-impl From<Error> for SnmpError {
-    fn from(e: Error) -> SnmpError {
-        SnmpError::BerError(e)
     }
 }
 

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -3,7 +3,7 @@ use crate::snmp::*;
 use crate::snmpv3::*;
 use asn1_rs::{Any, FromBer, Tag};
 use nom::combinator::map_res;
-use nom::{Err, IResult};
+use nom::{Err, Finish, IResult};
 
 #[derive(Debug, PartialEq)]
 pub enum SnmpGenericMessage<'a> {
@@ -47,7 +47,12 @@ fn parse_snmp_v3_pdu_content(i: &[u8]) -> IResult<&[u8], SnmpV3Message, SnmpErro
     Ok((i, msg))
 }
 
-pub fn parse_snmp_generic_message(i: &[u8]) -> IResult<&[u8], SnmpGenericMessage, SnmpError> {
+/// Parse any valid SNMP message.
+pub fn parse_snmp_generic_message(i: &[u8]) -> Result<(&[u8], SnmpGenericMessage), SnmpError> {
+    internal_parse_snmp_generic_message(i).finish()
+}
+
+fn internal_parse_snmp_generic_message(i: &[u8]) -> IResult<&[u8], SnmpGenericMessage, SnmpError> {
     let (rem, any) = Any::from_ber(i).or(Err(Err::Error(SnmpError::InvalidMessage)))?;
     if any.tag() != Tag::Sequence {
         return Err(Err::Error(SnmpError::InvalidMessage));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,3 +48,6 @@ pub mod snmpv3;
 pub use generic::*;
 pub use snmp::*;
 pub use snmpv3::*;
+
+// re-exports to prevent public dependency on asn1_rs
+pub use asn1_rs::{Oid, OidParseError};

--- a/src/snmp.rs
+++ b/src/snmp.rs
@@ -13,7 +13,7 @@ use asn1_rs::{
     Any, BitString, Class, Error, FromBer, Header, Implicit, Integer, Sequence, Tag, TaggedValue,
 };
 use nom::combinator::map;
-use nom::{Err, IResult};
+use nom::{Err, Finish, IResult};
 use std::convert::TryFrom;
 use std::net::Ipv4Addr;
 use std::slice::Iter;
@@ -534,7 +534,11 @@ fn parse_snmp_v1_trap_pdu(i: &[u8]) -> IResult<&[u8], SnmpPdu, SnmpError> {
 /// }
 /// # }
 /// ```
-pub fn parse_snmp_v1(bytes: &[u8]) -> IResult<&[u8], SnmpMessage, SnmpError> {
+pub fn parse_snmp_v1(bytes: &[u8]) -> Result<(&[u8], SnmpMessage), SnmpError> {
+    internal_parse_snmp_v1(bytes).finish()
+}
+
+fn internal_parse_snmp_v1(bytes: &[u8]) -> IResult<&[u8], SnmpMessage, SnmpError> {
     Sequence::from_der_and_then(bytes, |i| {
         let (i, version) = u32::from_ber(i).map_err(Err::convert)?;
         if version != 0 {
@@ -588,7 +592,11 @@ pub(crate) fn parse_snmp_v1_pdu(i: &[u8]) -> IResult<&[u8], SnmpPdu, SnmpError> 
 ///                 ANY
 ///         }
 /// </pre>
-pub fn parse_snmp_v2c(bytes: &[u8]) -> IResult<&[u8], SnmpMessage, SnmpError> {
+pub fn parse_snmp_v2c(bytes: &[u8]) -> Result<(&[u8], SnmpMessage), SnmpError> {
+    internal_parse_snmp_v2c(bytes).finish()
+}
+
+fn internal_parse_snmp_v2c(bytes: &[u8]) -> IResult<&[u8], SnmpMessage, SnmpError> {
     Sequence::from_der_and_then(bytes, |i| {
         let (i, version) = u32::from_ber(i).map_err(Err::convert)?;
         if version != 1 {

--- a/src/snmp.rs
+++ b/src/snmp.rs
@@ -8,10 +8,9 @@
 //!   - [RFC3416](https://tools.ietf.org/html/rfc3416): SNMP v2
 //!   - [RFC2570](https://tools.ietf.org/html/rfc2570): Introduction to SNMP v3
 
-use crate::error::SnmpError;
+use crate::{error::SnmpError, Oid};
 use asn1_rs::{
-    Any, BitString, Class, Error, FromBer, Header, Implicit, Integer, Oid, Sequence, Tag,
-    TaggedValue,
+    Any, BitString, Class, Error, FromBer, Header, Implicit, Integer, Sequence, Tag, TaggedValue,
 };
 use nom::combinator::map;
 use nom::{Err, IResult};

--- a/src/snmpv3.rs
+++ b/src/snmpv3.rs
@@ -10,7 +10,7 @@
 
 use asn1_rs::{Error, FromBer, Sequence};
 use nom::combinator::{map, map_res};
-use nom::{Err, IResult};
+use nom::{Err, Finish, IResult};
 use std::fmt;
 
 use crate::error::SnmpError;
@@ -167,7 +167,11 @@ pub(crate) fn parse_secp<'a>(
 /// }
 /// # }
 /// ```
-pub fn parse_snmp_v3(bytes: &[u8]) -> IResult<&[u8], SnmpV3Message, SnmpError> {
+pub fn parse_snmp_v3(bytes: &[u8]) -> Result<(&[u8], SnmpV3Message), SnmpError> {
+    internal_parse_snmp_v3(bytes).finish()
+}
+
+fn internal_parse_snmp_v3(bytes: &[u8]) -> IResult<&[u8], SnmpV3Message, SnmpError> {
     Sequence::from_der_and_then(bytes, |i| {
         let (i, version) = u32::from_ber(i).map_err(Err::convert)?;
         let (i, header_data) = parse_snmp_v3_headerdata(i)?;

--- a/src/usm.rs
+++ b/src/usm.rs
@@ -2,7 +2,7 @@
 
 use crate::parse_ber_octetstring_as_str;
 use asn1_rs::{Error, FromBer, Sequence};
-use nom::IResult;
+use nom::{Finish, IResult};
 
 #[derive(Debug, PartialEq)]
 pub struct UsmSecurityParameters<'a> {
@@ -14,7 +14,15 @@ pub struct UsmSecurityParameters<'a> {
     pub msg_privacy_parameters: &'a [u8],
 }
 
-pub fn parse_usm_security_parameters(bytes: &[u8]) -> IResult<&[u8], UsmSecurityParameters, Error> {
+pub fn parse_usm_security_parameters(
+    bytes: &[u8],
+) -> Result<(&[u8], UsmSecurityParameters), Error> {
+    internal_parse_usm_security_parameters(bytes).finish()
+}
+
+fn internal_parse_usm_security_parameters(
+    bytes: &[u8],
+) -> IResult<&[u8], UsmSecurityParameters, Error> {
     Sequence::from_der_and_then(bytes, |i| {
         let (i, msg_authoritative_engine_id) = <&[u8]>::from_ber(i)?;
         let (i, msg_authoritative_engine_boots) = u32::from_ber(i)?;

--- a/tests/v1.rs
+++ b/tests/v1.rs
@@ -1,6 +1,5 @@
 #[macro_use]
 extern crate hex_literal;
-extern crate nom;
 extern crate snmp_parser;
 
 use snmp_parser::*;

--- a/tests/v1.rs
+++ b/tests/v1.rs
@@ -3,7 +3,6 @@ extern crate hex_literal;
 extern crate nom;
 extern crate snmp_parser;
 
-use asn1_rs::Oid;
 use snmp_parser::*;
 use std::net::Ipv4Addr;
 

--- a/tests/v2c.rs
+++ b/tests/v2c.rs
@@ -1,6 +1,5 @@
 #[macro_use]
 extern crate pretty_assertions;
-extern crate nom;
 extern crate snmp_parser;
 
 use snmp_parser::*;

--- a/tests/v2c.rs
+++ b/tests/v2c.rs
@@ -3,7 +3,6 @@ extern crate pretty_assertions;
 extern crate nom;
 extern crate snmp_parser;
 
-use asn1_rs::Oid;
 use snmp_parser::*;
 
 static SNMPV2_GET: &[u8] = include_bytes!("../assets/snmpv2c-get-response.bin");

--- a/tests/v3.rs
+++ b/tests/v3.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate pretty_assertions;
 
-extern crate nom;
 extern crate snmp_parser;
 
 use snmp_parser::*;


### PR DESCRIPTION
Hi,
thanks for implementing this parser crate. It helps a lot. However, while including the crate in my business logic a found some unergonomic API designs that this PR tries to solve.

The main problem I found is that there are types of the crate's dependencies in the crate's public API. Namely, types from asn1-rs and nom. This required me to also depend on these crate to handle OIDs and to handle nom parser errors. But this gets problematic when versions between snmp-parser, asn1-rs and nom start to differ. Actually, there is already a difference between nom v7.0 used in snmp-parser and the current nom version v7.1.

This PR removes those public dependencies via re-export or returning std types instead. Feel free to cherry pick single commits. I'm also open to discuss alternative solutions.